### PR TITLE
Adds new cache db and writes a materialized view with score every 10 minutes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ dist
 .pnp.*
 
 local.*
+cache.*

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,7 +1,6 @@
 import Fastify from "fastify";
 import {
   constructFeed,
-  parseCursor,
   trendingLinks,
   trendingLinksHourly,
 } from "./lib/feed.js";
@@ -56,7 +55,7 @@ server.route({
       limit: string;
     };
     const limit = parseInt(query.limit);
-    const cursor = parseCursor(query.cursor);
+    const cursor = query.cursor ? parseInt(query.cursor) : undefined;
 
     console.log("\nGOT", req.query, "\n");
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -55,7 +55,17 @@ server.route({
       limit: string;
     };
     const limit = parseInt(query.limit);
-    const cursor = query.cursor ? parseInt(query.cursor) : undefined;
+    let oldCursor = undefined;
+    if (query.cursor && query.cursor.includes("/")) {
+      // We don't need the date anymore, but can grab the index
+      const [, index] = query.cursor.split("/");
+      oldCursor = index;
+    }
+    const cursor = oldCursor
+      ? parseInt(oldCursor)
+      : query.cursor
+      ? parseInt(query.cursor)
+      : 0;
 
     console.log("\nGOT", req.query, "\n");
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,6 +1,7 @@
 import Fastify from "fastify";
 import {
   constructFeed,
+  parseCursor,
   trendingLinks,
   trendingLinksHourly,
 } from "./lib/feed.js";
@@ -55,17 +56,7 @@ server.route({
       limit: string;
     };
     const limit = parseInt(query.limit);
-    let oldCursor = undefined;
-    if (query.cursor && query.cursor.includes("/")) {
-      // We don't need the date anymore, but can grab the index
-      const [, index] = query.cursor.split("/");
-      oldCursor = index;
-    }
-    const cursor = oldCursor
-      ? parseInt(oldCursor)
-      : query.cursor
-      ? parseInt(query.cursor)
-      : 0;
+    const cursor = query.cursor ? parseCursor(query.cursor) : undefined;
 
     console.log("\nGOT", req.query, "\n");
 

--- a/src/cron.ts
+++ b/src/cron.ts
@@ -29,9 +29,20 @@ CronJob.from({
 });
 
 const writeCache = () => {
+  const range = "1 day";
+
   // Delete all old post views from cache
   cacheDb
-    .prepare("DELETE FROM post WHERE dateWritten < DATETIME('now', '-1 day');")
+    .prepare(
+      `DELETE FROM post WHERE dateWritten < DATETIME('now', '-${range}');`
+    )
+    .run();
+
+  // Delete all old dateWritten from cache
+  cacheDb
+    .prepare(
+      `DELETE FROM date_written WHERE dateWritten < DATETIME('now', '-${range}');`
+    )
     .run();
 
   // Write scored posts to cache
@@ -91,7 +102,7 @@ const writeCache = () => {
           LEFT JOIN local.reaction ON local.post.rkey = local.reaction.rkey
           AND local.post.did = local.reaction.did
         WHERE
-          local.post.createdAt >= DATETIME('now', '-1 day')
+          local.post.createdAt >= DATETIME('now', '-${range}')
         GROUP BY
           local.post.did,
           local.post.rkey,

--- a/src/cron.ts
+++ b/src/cron.ts
@@ -1,5 +1,5 @@
 import { CronJob } from "cron";
-import { db } from "./lib/db.js";
+import { cacheDb, db } from "./lib/db.js";
 
 // Delete old data
 CronJob.from({
@@ -10,7 +10,7 @@ CronJob.from({
     const deletePosts = db.prepare(
       `
         DELETE FROM post
-        WHERE createdAt < STRFTIME('%Y-%m-%d %H:%M:%S', 'now', '-2 day');
+        WHERE createdAt < DATETIME('now', '-2 day');
       `
     );
 
@@ -19,11 +19,67 @@ CronJob.from({
     // Delete posts older than 1 day
     const deleteReactions = db.prepare(
       `
-            DELETE FROM reaction
-            WHERE createdAt < STRFTIME('%Y-%m-%d %H:%M:%S', 'now', '-2 day');
-          `
+        DELETE FROM reaction
+        WHERE createdAt < DATETIME('now', '-2 day');
+      `
     );
 
     console.log("DELETE REACTIONS", deleteReactions.run());
+  },
+});
+
+CronJob.from({
+  start: true,
+  cronTime: "*/10 * * * *",
+  onTick: () => {
+    // Delete all posts from cache
+    cacheDb.prepare("DELETE FROM post;").run();
+
+    // Write scored posts to cache
+    const writePosts = cacheDb.prepare(
+      `
+      INSERT INTO post (did, rkey, url, createdAt, score, likes, reposts, comments)
+       SELECT
+        local.post.did,
+        local.post.rkey,
+        local.post.url,
+        local.post.createdAt,
+        COUNT(
+          CASE
+            WHEN local.reaction.type = 'like' THEN 1
+            WHEN local.reaction.type = 'repost' THEN 1
+          END
+        ) AS score,
+        COUNT(
+          CASE
+            WHEN local.reaction.type = 'like' THEN 1
+          END
+        ) AS likes,
+        COUNT(
+          CASE
+            WHEN local.reaction.type = 'repost' THEN 1
+          END
+        ) AS reposts,
+        COUNT(
+          CASE
+            WHEN local.reaction.type = 'comment' THEN 1
+          END
+        ) AS comments
+      FROM
+        local.post
+      LEFT JOIN local.reaction ON local.post.rkey = local.reaction.rkey
+      AND local.post.did = local.reaction.did
+      WHERE
+        local.post.createdAt >= DATETIME('now', '-1 day')
+      GROUP BY
+        local.post.did,
+        local.post.rkey,
+        local.post.url
+      ORDER BY
+          score DESC;
+      `
+    );
+
+    console.log("WRITE POSTS", writePosts.run());
   },
 });

--- a/src/cron.ts
+++ b/src/cron.ts
@@ -104,7 +104,16 @@ const writeCache = () => {
       `
   );
 
-  console.log("WRITE POSTS", writePosts.run());
+  const lastRun = writePosts.run();
+  cacheDb
+    .prepare(
+      `INSERT INTO date_written (dateWritten)
+      SELECT dateWritten FROM post WHERE rowid = ?;
+      `
+    )
+    .run(lastRun.lastInsertRowid);
+
+  console.log("WRITE POSTS", lastRun);
 };
 
 // write cache immediately at startup

--- a/src/cron.ts
+++ b/src/cron.ts
@@ -29,8 +29,10 @@ CronJob.from({
 });
 
 const writeCache = () => {
-  // Delete all posts from cache
-  cacheDb.prepare("DELETE FROM post;").run();
+  // Delete all old post views from cache
+  cacheDb
+    .prepare("DELETE FROM post WHERE dateWritten < DATETIME('now', '-1 day');")
+    .run();
 
   // Write scored posts to cache
   const writePosts = cacheDb.prepare(
@@ -45,7 +47,8 @@ const writeCache = () => {
         decay,
         likes,
         reposts,
-        comments
+        comments,
+        dateWritten
       )
       SELECT
         did,
@@ -57,7 +60,8 @@ const writeCache = () => {
         decay,
         likes,
         reposts,
-        comments
+        comments,
+        DATETIME('now') as dateWritten
       FROM
         (
           SELECT
@@ -108,6 +112,6 @@ writeCache();
 
 CronJob.from({
   start: true,
-  cronTime: "*/10 * * * *",
+  cronTime: "0 * * * *",
   onTick: writeCache,
 });

--- a/src/cron.ts
+++ b/src/cron.ts
@@ -1,7 +1,7 @@
 import { CronJob } from "cron";
 import { cacheDb, db } from "./lib/db.js";
 
-// Delete old data
+// Delete old data every hour
 CronJob.from({
   start: true,
   cronTime: "0 * * * *",
@@ -130,8 +130,9 @@ const writeCache = () => {
 // write cache immediately at startup
 writeCache();
 
+// Generate a new feed every 10 minutes
 CronJob.from({
   start: true,
-  cronTime: "0 * * * *",
+  cronTime: "0/10 * * * *",
   onTick: writeCache,
 });

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -28,6 +28,16 @@ export interface Post {
   createdAt: string;
 }
 
+// Create dateWritten table to store each unique dateWritten
+cacheDb
+  .prepare(
+    `CREATE TABLE IF NOT EXISTS date_written (
+    dateWritten DATETIME NOT NULL,
+    PRIMARY KEY (dateWritten)
+  )`
+  )
+  .run();
+
 cacheDb
   .prepare(
     `CREATE TABLE IF NOT EXISTS post (

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,9 +1,14 @@
 import Database from "libsql";
 
 export const db = new Database(process.env.DB_URL || "./local.db");
+export const cacheDb = new Database(process.env.CACHE_DB_URL || "./cache.db");
 
 // Allows the other process to read from the database while we're writing to it
 db.exec("PRAGMA journal_mode = WAL;");
+cacheDb.exec("PRAGMA journal_mode = WAL;");
+cacheDb.exec(
+  `ATTACH DATABASE '${process.env.DB_URL || "./local.db"}' AS local;`
+);
 
 db.prepare(
   `CREATE TABLE IF NOT EXISTS post (
@@ -22,14 +27,28 @@ export interface Post {
   createdAt: string;
 }
 
-db.prepare(
-  `CREATE TABLE IF NOT EXISTS cache (
-    key TEXT NOT NULL, 
-    value TEXT NOT NULL, 
-    PRIMARY KEY (key)
-  )`
-).run();
-db.prepare(`DELETE FROM cache`).run();
+cacheDb
+  .prepare(
+    `CREATE TABLE IF NOT EXISTS post (
+      did TEXT NOT NULL, 
+      rkey TEXT NOT NULL, 
+      url TEXT NOT NULL, 
+      createdAt DATETIME DEFAULT CURRENT_TIMESTAMP,
+      score INTEGER DEFAULT 0,
+      likes INTEGER DEFAULT 0,
+      reposts INTEGER DEFAULT 0,
+      comments INTEGER DEFAULT 0,
+      PRIMARY KEY (createdAt, score, url, rkey, did)
+    )`
+  )
+  .run();
+
+export interface PostWithData extends Post {
+  score: number;
+  likes: number;
+  reposts: number;
+  comments: number;
+}
 
 export function addPost(data: Omit<Post, "createdAt">) {
   const result = db
@@ -69,21 +88,20 @@ export function addReaction(
   data: Omit<Reaction, "createdAt" | "rkey" | "did">
 ) {
   const { did, rkey } = parseUri(data.url);
-  const post = db
-    .prepare(`SELECT 1 FROM post WHERE did = ? AND rkey = ?`)
-    .get(did, rkey) as Post | undefined;
-
-  if (!post) {
-    return;
-  }
-
   const id = `${data.id}-${data.type}-${new Date().getTime()}`;
   const result = db
     .prepare(
-      `INSERT OR IGNORE INTO reaction (id, type, did, rkey) VALUES (?, ?, ?, ?)`
+      `
+      INSERT OR IGNORE INTO reaction (id, type, did, rkey)
+      SELECT ?, ?, ?, ?
+      WHERE EXISTS (SELECT 1 FROM post WHERE did = ? AND rkey = ?)
+      `
     )
-    .run(id, data.type, did, rkey);
+    .run(id, data.type, did, rkey, did, rkey);
 
+  if (result.changes === 0) {
+    return;
+  }
   console.log("ADD REACTION", result);
 }
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -40,7 +40,8 @@ cacheDb
       likes INTEGER DEFAULT 0,
       reposts INTEGER DEFAULT 0,
       comments INTEGER DEFAULT 0,
-      PRIMARY KEY (createdAt, score, url, rkey, did)
+      dateWritten DATETIME DEFAULT CURRENT_TIMESTAMP,
+      PRIMARY KEY (dateWritten, createdAt, score, url, rkey, did)
     )`
   )
   .run();
@@ -52,6 +53,7 @@ export interface PostWithData extends Post {
   likes: number;
   reposts: number;
   comments: number;
+  dateWritten: string;
 }
 
 export function addPost(data: Omit<Post, "createdAt">) {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,14 +1,15 @@
 import Database from "libsql";
 
-export const db = new Database(process.env.DB_URL || "./local.db");
-export const cacheDb = new Database(process.env.CACHE_DB_URL || "./cache.db");
+const dbPath = process.env.DB_URL || "./local.db";
+const cacheDbPath = process.env.CACHE_DB_URL || "./cache.db";
+
+export const db = new Database(dbPath);
+export const cacheDb = new Database(cacheDbPath);
 
 // Allows the other process to read from the database while we're writing to it
 db.exec("PRAGMA journal_mode = WAL;");
 cacheDb.exec("PRAGMA journal_mode = WAL;");
-cacheDb.exec(
-  `ATTACH DATABASE '${process.env.DB_URL || "./local.db"}' AS local;`
-);
+cacheDb.exec(`ATTACH DATABASE '${dbPath}' AS local;`);
 
 db.prepare(
   `CREATE TABLE IF NOT EXISTS post (

--- a/src/lib/feed.ts
+++ b/src/lib/feed.ts
@@ -62,7 +62,7 @@ export async function rankLinks({
 
   return {
     items: posts,
-    cursor: `${posts[posts.length - 1]?.dateWritten || cursor.time}/${
+    cursor: `${cursor.time || posts[posts.length - 1]?.dateWritten}/${
       (cursor.index || 0) + (posts.length === limit ? limit : posts.length)
     }`,
   };

--- a/src/lib/feed.ts
+++ b/src/lib/feed.ts
@@ -1,21 +1,8 @@
-import { db, getStartTime, Post } from "./db.js";
+import { db, Post } from "./db.js";
 
 interface PostWithData extends Post {
   uri: string;
   url: string;
-}
-
-function getPostScore(post: PostWithData) {
-  // calculate a decaying score based on the last 24 hours
-  // the older the post the lesser the score
-  const timeDiff = Date.now() - new Date(post.createdAt).getTime();
-  const decay = 1 - timeDiff / 1000 / 60 / 60 / 24;
-
-  return (post.likes + post.reposts + post.comments) * decay;
-}
-
-function sumPostScore(posts: PostWithData[]) {
-  return posts.reduce((acc, post) => acc + getPostScore(post), 0);
 }
 
 interface PostWithData extends Post {
@@ -37,103 +24,68 @@ export type ParsedCursor = ReturnType<typeof parseCursor>;
 
 export interface RankLinksOptions {
   limit: number;
-  cursor?: ParsedCursor;
+  cursor?: number;
   range?: string;
 }
 
 export async function rankLinks({
   limit,
-  cursor = { startTime: undefined, index: undefined },
+  cursor,
   range = "1 day",
 }: RankLinksOptions) {
-  const defaultStartTime = getStartTime();
-  const startTime = cursor.startTime ?? defaultStartTime;
-  const cacheKey = `${startTime}/${range}`;
-  const cached = db
-    .prepare(`SELECT value FROM cache WHERE key = ?`)
-    .get(cacheKey) as { value: string } | undefined;
-
-  let items: [string, PostWithData[]][];
-
-  if (cached) {
-    console.log("CACHE HIT", cacheKey);
-    items = JSON.parse(cached.value);
-  } else {
-    console.log("CACHE MISS", cacheKey);
-    const minTime = `DATETIME('${startTime}', '-${range}')`;
-    const maxTime = `DATETIME('${startTime}')`;
-
-    const posts = db
-      .prepare(
-        `
-          SELECT 
-              post.did,
-              post.rkey,
-              post.url,
-              post.createdAt,
-              COUNT(CASE WHEN reaction.type = 'like' THEN 1 END) AS likes,
-              COUNT(CASE WHEN reaction.type = 'repost' THEN 1 END) AS reposts,
-              COUNT(CASE WHEN reaction.type = 'comment' THEN 1 END) AS comments
-          FROM 
-              post
-              LEFT JOIN reaction ON post.rkey = reaction.rkey AND post.did = reaction.did
-          WHERE
-              post.createdAt >= ${minTime}
-              AND post.createdAt <= ${maxTime}
-              AND (reaction.createdAt >= ${minTime} AND post.createdAt <= ${maxTime} OR reaction.createdAt IS NULL)
-          GROUP BY
-              post.did, post.rkey, post.url, post.createdAt;
-        `
-      )
-      .all() as PostWithData[];
-
-    const top: Record<string, PostWithData[]> = {};
-
-    for (let i = 0; i < posts.length; i++) {
-      const post = posts[i];
-
-      if (!post) {
-        continue;
-      }
-
-      if (!top[post.url]) {
-        top[post.url] = [];
-      }
-
-      top[post.url]?.push(post);
-    }
-
-    items = Object.entries(top)
-      .sort((a, b) => sumPostScore(b[1]) - sumPostScore(a[1]))
-      .map(([url, posts]): [string, PostWithData[]] => [
+  const posts = db
+    .prepare(
+      `
+      SELECT
+        did,
+        rkey,
         url,
-        posts.sort((a, b) => getPostScore(b) - getPostScore(a)),
-      ])
-      .slice(0, 1500);
-
-    db.prepare(`INSERT OR REPLACE INTO cache (key, value) VALUES (?, ?)`).run(
-      cacheKey,
-      JSON.stringify(items)
-    );
-  }
-
-  if (cursor.index) {
-    items = items.slice(cursor.index + 1);
-  }
-
-  items = items.slice(0, limit);
+        createdAt,
+        likes + reposts AS score,
+        likes,
+        reposts,
+        comments
+      FROM
+        (
+          SELECT
+            post.did,
+            post.rkey,
+            post.url,
+            post.createdAt,
+            COUNT(CASE WHEN reaction.type = 'like' THEN 1 END) AS likes,
+            COUNT(CASE WHEN reaction.type = 'repost' THEN 1 END) AS reposts,
+            COUNT(CASE WHEN reaction.type = 'comment' THEN 1 END) AS comments
+          FROM
+            post
+          LEFT JOIN reaction ON post.rkey = reaction.rkey
+          AND post.did = reaction.did
+          WHERE
+            post.createdAt >= DATETIME(
+              'now',
+              '-${range}'
+            )
+          GROUP BY
+            post.did,
+            post.rkey,
+            post.url
+        )
+      ORDER BY
+        score DESC
+      LIMIT
+        ${limit}
+        ${cursor ? `OFFSET ${cursor}` : ""};
+        `
+    )
+    .all() as PostWithData[];
 
   return {
-    items: Object.fromEntries(items),
-    cursor: `${startTime}/${(cursor.index || 0) + limit}`,
+    items: posts,
+    cursor: (cursor || 0) + limit,
   };
 }
 
-export function constructFeed(
-  items: Awaited<ReturnType<typeof rankLinks>>["items"]
-) {
-  return Object.values(items).map((item) => {
-    const post = item[0]!;
+export function constructFeed(items: PostWithData[]) {
+  return items.map((post) => {
     return {
       post: `at://${post.did}/app.bsky.feed.post/${post.rkey}`,
     };

--- a/src/lib/feed.ts
+++ b/src/lib/feed.ts
@@ -43,9 +43,8 @@ export async function rankLinks({
           SELECT
             dateWritten
           FROM
-            post
+            date_written
           WHERE
-            createdAt >= ${cursorDateTime} AND
             dateWritten >= ${cursorDateTime}
           ORDER BY
             julianday(dateWritten) - julianday('${cursorTime}')


### PR DESCRIPTION
This allows us to have a consistent view every 10 minutes that is very fast to query against even with hundreds of thousands of posts in the table.

Because the cache is written out of band, the slowness of the query to create the view for the cache is largely unnoticed, though you're using the sync libsql API and it might make sense to use the async one to mitigate freezing the node.js process while any long queries happen.

I did my best to port the existing cursor to the new one, I couldn't test this as a feed in the UI so I don't know how it feels but all signs point to it being an overall better experience and easier to maintain.

Long term you could create feeds based just on likes, comments, reposts, or whatever you wanted to track because the queries against the cache db are super cheap.