### PR TITLE
Changes db access and migrations as well as splitting into multiple processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,15 @@ The feed uses the following strategy to rank posts:
 - For each link do the above and add them all together
 
 Posts are then ordered according to that score.
+
+## Caching
+
+The query that determines the score and subsequent ordering of posts is run out of bound from queries and cached to a separate database
+that acts like a read cache. It enables fast reads that generally are consistent regardless of where in the feed you are requesting.
+
+It is currently set to write to the cache every 10 minutes which means it is as fresh as possible but it also tracks when it was written to.
+Using this written time we can use it to lock a user to a specific view based on when it was written to give them a consistent feed
+until they refresh it or it expires in 24 hours.
+
+Any posts that are below 10 score points are not cached and omitted from the feed. This happens to be about 90% of all links processed
+but as you can guess most posts with links have very little traction and it doesn't make much sense for this feed to show them.

--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "start": "tsx src/entry.ts",
-    "lint": "eslint ."
+    "start": "concurrently \"tsx src/entry.ts\" \"tsx src/stream.ts\" \"tsx src/cron.ts\"",
+    "lint": "eslint .",
+    "db:migrate": "tsx src/migrations/index.ts",
+    "db:rollback": "tsx src/migrations/index.ts --rollback"
   },
   "keywords": [],
   "author": "Andrew Lisowski",
@@ -27,6 +29,7 @@
     "@eslint/js": "^9.14.0",
     "@types/node": "^22.9.0",
     "@types/ws": "^8.5.13",
+    "concurrently": "^9.1.0",
     "eslint": "^9.14.0",
     "globals": "^15.12.0",
     "inquirer": "^12.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@types/ws':
         specifier: ^8.5.13
         version: 8.5.13
+      concurrently:
+        specifier: ^9.1.0
+        version: 9.1.0
       eslint:
         specifier: ^9.14.0
         version: 9.14.0
@@ -683,6 +686,10 @@ packages:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
     engines: {node: '>= 12'}
 
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -696,6 +703,11 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  concurrently@9.1.0:
+    resolution: {integrity: sha512-VxkzwMAn4LP7WyMnJNbHN5mKV9L2IbyDjpzemKr99sXNR3GqRNMMHdm7prV1ws9wg7ETj6WUkNOigZVsptwbgg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   content-disposition@0.5.4:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
@@ -793,6 +805,10 @@ packages:
     resolution: {integrity: sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
@@ -961,6 +977,10 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
   get-intrinsic@1.2.4:
     resolution: {integrity: sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==}
     engines: {node: '>= 0.4'}
@@ -1106,6 +1126,9 @@ packages:
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
   luxon@3.5.0:
     resolution: {integrity: sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ==}
@@ -1299,6 +1322,10 @@ packages:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
 
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
@@ -1378,6 +1405,9 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  shell-quote@1.8.1:
+    resolution: {integrity: sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==}
+
   side-channel@1.0.6:
     resolution: {integrity: sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==}
     engines: {node: '>= 0.4'}
@@ -1419,6 +1449,10 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  supports-color@8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
+
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
 
@@ -1447,6 +1481,10 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
 
   ts-api-utils@1.4.0:
     resolution: {integrity: sha512-032cPxaEKwM+GT3vA5JXNzIaizx388rhsSW79vGRNGXfRRAdEAn2mvk36PvK5HnOchyWZ7afLEXqYCvPCrzuzQ==}
@@ -1522,6 +1560,10 @@ packages:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
   ws@8.18.0:
     resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
     engines: {node: '>=10.0.0'}
@@ -1533,6 +1575,18 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -2185,6 +2239,12 @@ snapshots:
 
   cli-width@4.1.0: {}
 
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -2196,6 +2256,16 @@ snapshots:
       delayed-stream: 1.0.0
 
   concat-map@0.0.1: {}
+
+  concurrently@9.1.0:
+    dependencies:
+      chalk: 4.1.2
+      lodash: 4.17.21
+      rxjs: 7.8.1
+      shell-quote: 1.8.1
+      supports-color: 8.1.1
+      tree-kill: 1.2.2
+      yargs: 17.7.2
 
   content-disposition@0.5.4:
     dependencies:
@@ -2286,6 +2356,8 @@ snapshots:
       '@esbuild/win32-arm64': 0.23.1
       '@esbuild/win32-ia32': 0.23.1
       '@esbuild/win32-x64': 0.23.1
+
+  escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
 
@@ -2521,6 +2593,8 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  get-caller-file@2.0.5: {}
+
   get-intrinsic@1.2.4:
     dependencies:
       es-errors: 1.3.0
@@ -2666,6 +2740,8 @@ snapshots:
       p-locate: 5.0.0
 
   lodash.merge@4.6.2: {}
+
+  lodash@4.17.21: {}
 
   luxon@3.5.0: {}
 
@@ -2845,6 +2921,8 @@ snapshots:
 
   real-require@0.2.0: {}
 
+  require-directory@2.1.1: {}
+
   require-from-string@2.0.2: {}
 
   resolve-from@4.0.0: {}
@@ -2927,6 +3005,8 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  shell-quote@1.8.1: {}
+
   side-channel@1.0.6:
     dependencies:
       call-bind: 1.0.7
@@ -2968,6 +3048,10 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  supports-color@8.1.1:
+    dependencies:
+      has-flag: 4.0.0
+
   text-table@0.2.0: {}
 
   thread-stream@2.7.0:
@@ -2991,6 +3075,8 @@ snapshots:
   toad-cache@3.7.0: {}
 
   toidentifier@1.0.1: {}
+
+  tree-kill@1.2.2: {}
 
   ts-api-utils@1.4.0(typescript@5.6.3):
     dependencies:
@@ -3057,7 +3143,27 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   ws@8.18.0: {}
+
+  y18n@5.0.8: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -93,7 +93,7 @@ server.route({
   url: "/dump",
   handler: async (_, res) => {
     res.send({
-      posts: db.prepare(`SELECT * FROM post`).all(),
+      posts: await (await db.prepare(`SELECT * FROM post`)).all(),
     });
   },
 });

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -1,10 +1,4 @@
 import "dotenv/config";
 
-// Starts the firehose subscription
-import "./stream.js";
-
 // Starts the API server
 import "./api.js";
-
-// Starts the cron job
-import "./cron.js";

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -18,3 +18,6 @@ export const bannedHosts = [
 
 export const DID = "did:plc:m2sjv3wncvsasdapla35hzwj";
 export const HOST = "bsky-lnks-production.up.railway.app";
+
+export const dbPath = process.env.DB_URL || "./local.db";
+export const cacheDbPath = process.env.CACHE_DB_URL || "./cache.db";

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -23,7 +23,9 @@ db.prepare(
 ).run();
 try {
   db.prepare(`ALTER TABLE post ADD COLUMN text TEXT`).run();
-} catch (e) {}
+} catch (e) {
+  console.error(e);
+}
 
 export interface Post {
   did: string;

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,31 +1,14 @@
 import { CommitCreateEvent } from "@skyware/jetstream";
-import Database from "libsql";
+import Database from "libsql/promise";
 
-const dbPath = process.env.DB_URL || "./local.db";
-const cacheDbPath = process.env.CACHE_DB_URL || "./cache.db";
+import { dbPath, cacheDbPath } from "./constants.js";
 
-export const db = new Database(dbPath);
-export const cacheDb = new Database(cacheDbPath);
+export const db = new Database(dbPath, {});
+export const cacheDb = new Database(cacheDbPath, {});
 
 // Allows the other process to read from the database while we're writing to it
-db.exec("PRAGMA journal_mode = WAL;");
-cacheDb.exec("PRAGMA journal_mode = WAL;");
-cacheDb.exec(`ATTACH DATABASE '${dbPath}' AS local;`);
-
-db.prepare(
-  `CREATE TABLE IF NOT EXISTS post (
-    did TEXT NOT NULL, 
-    rkey TEXT NOT NULL, 
-    url TEXT NOT NULL, 
-    createdAt DATETIME DEFAULT CURRENT_TIMESTAMP,
-    PRIMARY KEY (did, rkey, url)
-  )`
-).run();
-try {
-  db.prepare(`ALTER TABLE post ADD COLUMN text TEXT`).run();
-} catch (e) {
-  console.error(e);
-}
+await db.exec("PRAGMA journal_mode = WAL;");
+await cacheDb.exec("PRAGMA journal_mode = WAL;");
 
 export interface Post {
   did: string;
@@ -33,35 +16,6 @@ export interface Post {
   url: string;
   createdAt: string;
 }
-
-// Create dateWritten table to store each unique dateWritten
-cacheDb
-  .prepare(
-    `CREATE TABLE IF NOT EXISTS date_written (
-    dateWritten DATETIME NOT NULL,
-    PRIMARY KEY (dateWritten)
-  )`
-  )
-  .run();
-
-cacheDb
-  .prepare(
-    `CREATE TABLE IF NOT EXISTS post (
-      did TEXT NOT NULL, 
-      rkey TEXT NOT NULL, 
-      url TEXT NOT NULL, 
-      createdAt DATETIME DEFAULT CURRENT_TIMESTAMP,
-      score REAL DEFAULT 0.0,
-      raw_score INTEGER DEFAULT 0,
-      decay REAL DEFAULT 0.0,
-      likes INTEGER DEFAULT 0,
-      reposts INTEGER DEFAULT 0,
-      comments INTEGER DEFAULT 0,
-      dateWritten DATETIME DEFAULT CURRENT_TIMESTAMP,
-      PRIMARY KEY (dateWritten, createdAt, score, url, rkey, did)
-    )`
-  )
-  .run();
 
 export interface PostWithData extends Post {
   score: number;
@@ -73,7 +27,7 @@ export interface PostWithData extends Post {
   dateWritten: string;
 }
 
-export function addPost(data: {
+export async function addPost(data: {
   event: CommitCreateEvent<"app.bsky.feed.post">;
   url: string;
 }) {
@@ -86,25 +40,18 @@ export function addPost(data: {
     text += `\n\n${data.event.commit.record.embed.external.title}\n\n${data.event.commit.record.embed.external.description}`;
   }
 
-  const result = db
-    .prepare(
-      `INSERT OR REPLACE INTO post (did, rkey, url, text) VALUES (?, ?, ?, ?)`
-    )
-    .run(data.event.did, data.event.commit.rkey, data.url, text);
+  try {
+    const result = (
+      await db.prepare(
+        `INSERT OR REPLACE INTO post (did, rkey, url, text) VALUES (?, ?, ?, ?)`
+      )
+    ).run(data.event.did, data.event.commit.rkey, data.url, text);
 
-  console.log("ADD POST", result);
+    console.log("ADD POST", result);
+  } catch (e) {
+    console.error(e);
+  }
 }
-
-db.prepare(
-  `CREATE TABLE IF NOT EXISTS reaction (
-    id TEXT NOT NULL, 
-    did TEXT NOT NULL, 
-    rkey TEXT NOT NULL, 
-    type TEXT NOT NULL,
-    createdAt DATETIME DEFAULT CURRENT_TIMESTAMP,
-    PRIMARY KEY (id)
-  )`
-).run();
 
 export interface Reaction {
   id: string;
@@ -121,20 +68,21 @@ function parseUri(uri: string) {
   return { did, rkey };
 }
 
-export function addReaction(
+export async function addReaction(
   data: Omit<Reaction, "createdAt" | "rkey" | "did">
 ) {
   const { did, rkey } = parseUri(data.url);
   const id = `${data.id}-${data.type}-${new Date().getTime()}`;
-  const result = db
-    .prepare(
+
+  const result = (
+    await db.prepare(
       `
       INSERT OR IGNORE INTO reaction (id, type, did, rkey)
       SELECT ?, ?, ?, ?
       WHERE EXISTS (SELECT 1 FROM post WHERE did = ? AND rkey = ?)
       `
     )
-    .run(id, data.type, did, rkey, did, rkey);
+  ).run(id, data.type, did, rkey, did, rkey);
 
   if (result.changes === 0) {
     return;
@@ -142,20 +90,20 @@ export function addReaction(
   console.log("ADD REACTION", result);
 }
 
-export function getStartTime() {
-  const defaultStartTime = db
-    .prepare(
+export async function getStartTime() {
+  const defaultStartTime = (
+    await db.prepare(
       `SELECT datetime(strftime('%s', 'now') - strftime('%s', 'now') % 600, 'unixepoch') AS value;`
     )
-    .get() as { value: string };
+  ).get() as { value: string };
 
   return defaultStartTime.value;
 }
 
-export function getCurrentTime() {
-  const defaultStartTime = db
-    .prepare(`SELECT STRFTIME('%Y-%m-%d %H:%M:%S', 'now') AS value;`)
-    .get() as { value: string };
+export async function getCurrentTime() {
+  const defaultStartTime = (
+    await db.prepare(`SELECT STRFTIME('%Y-%m-%d %H:%M:%S', 'now') AS value;`)
+  ).get() as { value: string };
 
   return defaultStartTime.value;
 }

--- a/src/lib/feed.ts
+++ b/src/lib/feed.ts
@@ -25,8 +25,8 @@ export async function rankLinks({
   const cursorTime = cursor.time || "now";
   const cursorDateTime = `DATETIME('${cursorTime}', '-${range}')`;
 
-  const posts = cacheDb
-    .prepare(
+  const posts = (await (
+    await cacheDb.prepare(
       `
       SELECT
         did,
@@ -58,7 +58,7 @@ export async function rankLinks({
         ${cursor.index ? `OFFSET ${cursor.index}` : ""};
         `
     )
-    .all() as PostWithData[];
+  ).all()) as PostWithData[];
 
   return {
     items: posts,

--- a/src/migrations/001.ts
+++ b/src/migrations/001.ts
@@ -1,0 +1,70 @@
+import Database from "libsql/promise";
+
+export const migration = async (db: Database, cacheDb: Database) => {
+  await db.exec(
+    `CREATE TABLE IF NOT EXISTS post (
+      did TEXT NOT NULL, 
+      rkey TEXT NOT NULL, 
+      url TEXT NOT NULL, 
+      createdAt DATETIME DEFAULT CURRENT_TIMESTAMP,
+      PRIMARY KEY (did, rkey, url)
+    )`
+  );
+
+  const hasText = (
+    await db.prepare(`
+    SELECT name FROM pragma_table_info('post') WHERE name = 'text'
+  `)
+  ).get();
+
+  if (!hasText) {
+    await db.exec(`
+      ALTER TABLE post ADD COLUMN text TEXT
+      WHERE NOT EXISTS ()
+    `);
+  }
+
+  await db.exec(
+    `CREATE TABLE IF NOT EXISTS reaction (
+      id TEXT NOT NULL, 
+      did TEXT NOT NULL, 
+      rkey TEXT NOT NULL, 
+      type TEXT NOT NULL,
+      createdAt DATETIME DEFAULT CURRENT_TIMESTAMP,
+      PRIMARY KEY (id)
+    )`
+  );
+
+  // Create dateWritten table to store each unique dateWritten
+  await cacheDb.exec(
+    `CREATE TABLE IF NOT EXISTS date_written (
+      dateWritten DATETIME NOT NULL,
+      PRIMARY KEY (dateWritten)
+    )`
+  );
+
+  await cacheDb.exec(
+    `CREATE TABLE IF NOT EXISTS post (
+      did TEXT NOT NULL, 
+      rkey TEXT NOT NULL, 
+      url TEXT NOT NULL, 
+      createdAt DATETIME DEFAULT CURRENT_TIMESTAMP,
+      score REAL DEFAULT 0.0,
+      raw_score INTEGER DEFAULT 0,
+      decay REAL DEFAULT 0.0,
+      likes INTEGER DEFAULT 0,
+      reposts INTEGER DEFAULT 0,
+      comments INTEGER DEFAULT 0,
+      dateWritten DATETIME DEFAULT CURRENT_TIMESTAMP,
+      PRIMARY KEY (dateWritten, createdAt, score, url, rkey, did)
+    )`
+  );
+};
+
+export const rollback = async (db: Database, cacheDb: Database) => {
+  await db.exec(`DROP TABLE post`);
+  await db.exec(`DROP TABLE reaction`);
+
+  await cacheDb.exec(`DROP TABLE post`);
+  await cacheDb.exec(`DROP TABLE date_written`);
+};

--- a/src/migrations/002.ts
+++ b/src/migrations/002.ts
@@ -1,0 +1,11 @@
+import Database from "libsql/promise";
+
+export const migration = async (_: Database, cacheDb: Database) => {
+  const deletePosts = (
+    await cacheDb.prepare(`DELETE FROM post WHERE score <= 10;`)
+  ).run();
+
+  console.log("DELETE POSTS", deletePosts);
+};
+
+export const rollback = async () => {};

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -1,0 +1,28 @@
+import { db, cacheDb } from "../lib/db.js";
+import { migration as migration001, rollback as rollback001 } from "./001.js";
+
+export const migrations = [
+  migration001,
+  // more migrations here
+];
+const runMigrations = async () => {
+  for (const migration of migrations) {
+    await migration(db, cacheDb);
+  }
+};
+
+const rollbacks = [
+  rollback001,
+  // more rollbacks here
+];
+const rollbackMigrations = async () => {
+  for (const migration of rollbacks.reverse()) {
+    await migration(db, cacheDb);
+  }
+};
+
+if (process.argv.includes("--rollback")) {
+  await rollbackMigrations();
+} else {
+  await runMigrations();
+}

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -1,8 +1,10 @@
 import { db, cacheDb } from "../lib/db.js";
 import { migration as migration001, rollback as rollback001 } from "./001.js";
+import { migration as migration002, rollback as rollback002 } from "./002.js";
 
 export const migrations = [
   migration001,
+  migration002,
   // more migrations here
 ];
 const runMigrations = async () => {
@@ -13,6 +15,7 @@ const runMigrations = async () => {
 
 const rollbacks = [
   rollback001,
+  rollback002,
   // more rollbacks here
 ];
 const rollbackMigrations = async () => {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1,3 +1,4 @@
+import "dotenv/config";
 import { URL } from "url";
 import { Jetstream } from "@skyware/jetstream";
 import WebSocket from "ws";


### PR DESCRIPTION
Lots of changes, I didn't mean to stack it all in one PR, but here we go.

 * Only cache posts with a score > 10
 * Move migrations to separate migration folder with commands to run them
 * Split cron, feed, stream scripts into separate processes that run at the same time
   * This is to avoid the forced sync nature of some db actions, e.g. cron job cache read is slow and blocks everything in the same process
  * Move to async db access wherever we can, it isn't the most useful since some of the query commands are still sync


